### PR TITLE
Ci fix functional handoff and connection testing of maint events 2

### DIFF
--- a/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
@@ -18,7 +18,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +34,6 @@ import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.RedisFuture;
-import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.protocol.MaintenanceAwareExpiryWriter;
@@ -99,7 +97,7 @@ public class ConnectionHandoffTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("m1-standard");
+        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
@@ -99,7 +99,7 @@ public class ConnectionHandoffTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("re-standalone");
+        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
@@ -442,16 +442,13 @@ public class ConnectionHandoffTest {
         // Get cluster configuration for the operation
         String endpointId = clusterConfig.getFirstEndpointId();
         String policy = "single";
-        String sourceNode = clusterConfig.getOptimalSourceNode();
-        String targetNode = clusterConfig.getOptimalTargetNode();
 
         log.info("=== {} ===", testDescription);
         log.info("Expected address type: {}", context.expectedAddressType);
-        log.info("Starting migrate + moving operation...");
-        log.info("Using nodes: source={}, target={}", sourceNode, targetNode);
+        log.info("Starting migrate + moving operation with endpoint-aware node selection...");
 
-        // Trigger the migrate + moving operation
-        StepVerifier.create(faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, sourceNode, targetNode))
+        // Trigger the migrate + moving operation using endpoint-aware node selection
+        StepVerifier.create(faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, clusterConfig))
                 .expectNext(true).expectComplete().verify(LONG_OPERATION_TIMEOUT);
 
         // Wait for MIGRATED notification first (migration completes before endpoint rebind)
@@ -1049,15 +1046,12 @@ public class ConnectionHandoffTest {
         // Trigger operations that should generate all 5 notification types
         String endpointId = clusterConfig.getFirstEndpointId();
         String policy = "single";
-        String sourceNode = clusterConfig.getOptimalSourceNode();
-        String targetNode = clusterConfig.getOptimalTargetNode();
 
         log.info("Starting comprehensive maintenance operations to trigger all notification types...");
-        log.info("Using nodes: source={}, target={}", sourceNode, targetNode);
 
         // This operation will trigger MIGRATING, MIGRATED, and MOVING notifications
-        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, sourceNode, targetNode))
-                .expectNext(true).expectComplete().verify(LONG_OPERATION_TIMEOUT);
+        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, clusterConfig)).expectNext(true)
+                .expectComplete().verify(LONG_OPERATION_TIMEOUT);
 
         // Wait for initial notifications
         boolean received = capture.waitForNotifications(NOTIFICATION_WAIT_TIMEOUT);
@@ -1130,15 +1124,12 @@ public class ConnectionHandoffTest {
         // Trigger the same operations as the enabled test
         String endpointId = clusterConfig.getFirstEndpointId();
         String policy = "single";
-        String sourceNode = clusterConfig.getOptimalSourceNode();
-        String targetNode = clusterConfig.getOptimalTargetNode();
 
         log.info("Starting maintenance operations with disabled notifications...");
-        log.info("Using nodes: source={}, target={}", sourceNode, targetNode);
 
         // This operation would normally trigger notifications, but they should be disabled
-        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, sourceNode, targetNode))
-                .expectNext(true).expectComplete().verify(LONG_OPERATION_TIMEOUT);
+        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, clusterConfig)).expectNext(true)
+                .expectComplete().verify(LONG_OPERATION_TIMEOUT);
 
         // Wait to see if any notifications are received (they shouldn't be)
         boolean received = capture.waitForNotifications(Duration.ofSeconds(30));
@@ -1212,16 +1203,13 @@ public class ConnectionHandoffTest {
         // Get cluster configuration for the operation
         String endpointId = clusterConfig.getFirstEndpointId();
         String policy = "single";
-        String sourceNode = clusterConfig.getOptimalSourceNode();
-        String targetNode = clusterConfig.getOptimalTargetNode();
 
         log.info("Expected address type: {} (none)", AddressType.NONE);
         log.info("Starting migrate + moving operation...");
-        log.info("Using nodes: source={}, target={}", sourceNode, targetNode);
 
         // Trigger the migrate + moving operation
-        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, sourceNode, targetNode))
-                .expectNext(true).expectComplete().verify(LONG_OPERATION_TIMEOUT);
+        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, clusterConfig)).expectNext(true)
+                .expectComplete().verify(LONG_OPERATION_TIMEOUT);
 
         // Wait for MIGRATED notification first (migration completes before endpoint rebind)
         log.info("Waiting for MIGRATED notification...");
@@ -1417,14 +1405,12 @@ public class ConnectionHandoffTest {
         String bdbId = String.valueOf(mStandard.getBdbId());
         String endpointId = clusterConfig.getFirstEndpointId();
         String policy = "single";
-        String sourceNode = clusterConfig.getOptimalSourceNode();
-        String targetNode = clusterConfig.getOptimalTargetNode();
 
-        log.info("Triggering migrate + bind operation: source={}, target={}", sourceNode, targetNode);
+        log.info("Triggering migrate + bind operation with endpoint-aware node selection...");
 
         // Trigger the migrate + bind operation that causes connection handoff
-        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, sourceNode, targetNode))
-                .expectNext(true).expectComplete().verify(Duration.ofMinutes(3));
+        StepVerifier.create(faultClient.triggerMovingNotification(bdbId, endpointId, policy, clusterConfig)).expectNext(true)
+                .expectComplete().verify(Duration.ofMinutes(3));
 
         log.info("Migrate + bind operation completed, waiting for connection events...");
 

--- a/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
@@ -99,7 +99,7 @@ public class ConnectionHandoffTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
+        mStandard = Endpoints.DEFAULT.getEndpoint("m1-standard");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionHandoffTest.java
@@ -99,7 +99,7 @@ public class ConnectionHandoffTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
+        mStandard = Endpoints.DEFAULT.getEndpoint("re-standalone");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/MaintenanceNotificationTest.java
+++ b/src/test/java/io/lettuce/scenario/MaintenanceNotificationTest.java
@@ -79,7 +79,7 @@ public class MaintenanceNotificationTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
+        mStandard = Endpoints.DEFAULT.getEndpoint("re-standalone");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/MaintenanceNotificationTest.java
+++ b/src/test/java/io/lettuce/scenario/MaintenanceNotificationTest.java
@@ -79,7 +79,7 @@ public class MaintenanceNotificationTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("re-standalone");
+        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/MaintenanceNotificationTest.java
+++ b/src/test/java/io/lettuce/scenario/MaintenanceNotificationTest.java
@@ -210,20 +210,15 @@ public class MaintenanceNotificationTest {
         NotificationTestContext context = setupNotificationTest();
 
         // Trigger MOVING notification using the proper two-step process:
-        // 1. Migrate all shards from source node to target node (making it empty)
+        // 1. Migrate all shards from the node where the endpoint is bound
         // 2. Bind endpoint to trigger MOVING notification
         // Dynamically discovered endpoint ID
         String endpointId = clusterConfig.getFirstEndpointId();
         // M-Standard uses single policy
         String policy = "single";
-        // Dynamically discovered source node (finds node with shards)
-        String sourceNode = clusterConfig.getOptimalSourceNode();
-        // Dynamically discovered target node (finds empty node)
-        String targetNode = clusterConfig.getOptimalTargetNode();
 
-        log.info("Triggering MOVING notification using proper two-step process...");
-        log.info("Using dynamic nodes: source={}, target={}", sourceNode, targetNode);
-        StepVerifier.create(faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, sourceNode, targetNode))
+        log.info("Triggering MOVING notification using endpoint-aware node selection...");
+        StepVerifier.create(faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, clusterConfig))
                 .expectNext(true).expectComplete().verify(LONG_OPERATION_TIMEOUT);
 
         // Wait for MOVING notification

--- a/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
+++ b/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
@@ -869,14 +869,12 @@ public class RelaxedTimeoutConfigurationTest {
 
             String endpointId = clusterConfig.getFirstEndpointId();
             String policy = "single";
-            String sourceNode = clusterConfig.getOptimalSourceNode();
-            String targetNode = clusterConfig.getOptimalTargetNode();
 
             // Start maintenance operation - notification handler will manage traffic automatically
-            log.info("Starting maintenance operation (migrate + rebind)...");
+            log.info("Starting maintenance operation (migrate + rebind) with endpoint-aware node selection...");
 
-            // Start the maintenance operation asynchronously
-            faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, sourceNode, targetNode).subscribe(
+            // Start the maintenance operation asynchronously using endpoint-aware node selection
+            faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, clusterConfig).subscribe(
                     result -> log.info("MOVING operation completed: {}", result),
                     error -> log.error("MOVING operation failed: {}", error.getMessage()));
 
@@ -1026,16 +1024,12 @@ public class RelaxedTimeoutConfigurationTest {
 
             String endpointId = clusterConfig.getFirstEndpointId();
             String policy = "single";
-            String sourceNode = clusterConfig.getOptimalSourceNode();
-            String targetNode = clusterConfig.getOptimalTargetNode();
-
             // Start maintenance operation - notification handler will manage traffic automatically
-            log.info("Starting maintenance operation (migrate + rebind)...");
+            log.info("Starting maintenance operation (migrate + rebind) with endpoint-aware node selection...");
 
             // Start the maintenance operation and wait for it to complete fully
-            log.info("Starting MOVING operation and waiting for it to complete...");
-            Boolean operationResult = faultClient
-                    .triggerMovingNotification(context.bdbId, endpointId, policy, sourceNode, targetNode)
+            log.info("Starting MOVING operation with endpoint-aware node selection and waiting for it to complete...");
+            Boolean operationResult = faultClient.triggerMovingNotification(context.bdbId, endpointId, policy, clusterConfig)
                     .block(Duration.ofMinutes(3));
             assertThat(operationResult).isTrue();
             log.info("MOVING operation fully completed: {}", operationResult);

--- a/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
+++ b/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
@@ -83,7 +83,7 @@ public class RelaxedTimeoutConfigurationTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("re-standalone");
+        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
+++ b/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
@@ -83,7 +83,7 @@ public class RelaxedTimeoutConfigurationTest {
 
     @BeforeAll
     public static void setup() {
-        mStandard = Endpoints.DEFAULT.getEndpoint("m-standard");
+        mStandard = Endpoints.DEFAULT.getEndpoint("re-standalone");
         assumeTrue(mStandard != null, "Skipping test because no M-Standard Redis endpoint is configured!");
     }
 


### PR DESCRIPTION
Multiple fixes for the configuration discovery and reset class
1. tests time reduced from 6 minutes and 40 seconds each to 3 minutes each
2. fixed a lot of hardcoded stuff that made the tests bug out in CI, and now we dynamically discover the DB configuration and should work in multi db environment with more than 3 nodes.

